### PR TITLE
Compatibility update for MixinMinecraft.java

### DIFF
--- a/src/main/java/me/earth/phobos/mixin/mixins/MixinMinecraft.java
+++ b/src/main/java/me/earth/phobos/mixin/mixins/MixinMinecraft.java
@@ -98,7 +98,7 @@ public abstract class MixinMinecraft {
         return !MultiTask.getInstance().isOn() && playerSP.isHandActive();
     }
 
-    @Redirect(method={"rightClickMouse"}, at=@At(value="INVOKE", target="Lnet/minecraft/client/multiplayer/PlayerControllerMP;getIsHittingBlock()Z", ordinal=0), require=1)
+    @Redirect(method={"rightClickMouse"}, at=@At(value="INVOKE", target="Lnet/minecraft/client/multiplayer/PlayerControllerMP;getIsHittingBlock()Z", ordinal=0))
     private boolean isHittingBlockHook(PlayerControllerMP playerControllerMP) {
         return !MultiTask.getInstance().isOn() && playerControllerMP.getIsHittingBlock();
     }


### PR DESCRIPTION
Basically, A2H keeps being messaged about phobos not being compatible with gamesense so this should fix that (along with many other clients). 

Credit to A2H for changes.